### PR TITLE
Refresh storage on every index call

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -106,7 +106,7 @@ where
         world: UnsafeWorldCell<'w2>,
         change_tick: Tick,
     ) -> Self::Item<'w2, 's2> {
-        Index {
+        let mut res = Index {
             storage: <ResMut<'w, I::Storage>>::get_param(
                 &mut state.storage_state,
                 system_meta,
@@ -123,7 +123,9 @@ where
                 world,
                 change_tick,
             ),
-        }
+        };
+        res.refresh();
+        res
     }
 }
 unsafe impl<'w, 's, I: IndexInfo + 'static> ReadOnlySystemParam for Index<'w, 's, I>

--- a/src/index.rs
+++ b/src/index.rs
@@ -250,9 +250,9 @@ mod test {
                 }
                 idx = nums_and_index.p1(); // reborrow here so earlier p0 borrow succeeds
 
-                // Hasn't refreshed yet
-                assert_eq!(idx.lookup(&Number(20)).len(), 1);
-                assert_eq!(idx.lookup(&Number(25)).len(), 0);
+                // Already refreshed
+                assert_eq!(idx.lookup(&Number(20)).len(), 0);
+                assert_eq!(idx.lookup(&Number(25)).len(), 1);
 
                 idx.refresh();
                 assert_eq!(idx.lookup(&Number(20)).len(), 0);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -69,11 +69,8 @@ impl<I: IndexInfo> IndexStorage<I> for HashmapStorage<I> {
     fn lookup<'w, 's>(
         &mut self,
         val: &I::Value,
-        data: &mut StaticSystemParam<Self::RefreshData<'w, 's>>,
+        _data: &mut StaticSystemParam<Self::RefreshData<'w, 's>>,
     ) -> HashSet<Entity> {
-        if self.last_refresh_tick != data.ticks.this_run() {
-            self.refresh(data);
-        }
         self.map.get(val)
     }
 


### PR DESCRIPTION
This PR makes the index get refreshed every time a system that uses it runs, rather than only on lookup. This prevents the user from accidentally missing a removed component, at the expense that refresh is now called all the time.

Fixes #5 