### PR TITLE
feat: Adds `reflect` feature to storage resources

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ rand = "0.8.5"
 [dev-dependencies.bevy]
 version = "0.13"
 features = ["dynamic_linking"]
+
+[features]
+reflect = []

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ and you can also define your own by implementing the `IndexRefreshPolicy` trait.
 | 0.11         | 0.2.0                    |
 | 0.10         | 0.1.0                    |
 
+## Features
+| Feature name | Description                                    |
+|--------------|------------------------------------------------|
+| `reflect`    | Adds reflect derives to the storage resources. |
+
 ## API Stability
 Consider the API to be extremely unstable as I experiment with what names and patterns feel
 most natural and expressive, and also work on supporting new features.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -6,6 +6,9 @@ use bevy::ecs::system::{StaticSystemParam, SystemChangeTick, SystemParam};
 use bevy::prelude::*;
 use std::marker::PhantomData;
 
+#[cfg(feature="reflect")]
+use bevy::{reflect::Reflect, ecs::prelude::ReflectResource};
+
 /// Defines the internal storage for an index, which is stored as a [`Resource`].
 ///
 /// You should not need this for normal use beyond including the `Storage` type
@@ -44,6 +47,8 @@ pub trait IndexStorage<I: IndexInfo>: Resource + Default {
 
 /// [`IndexStorage`] implementation that maintains a HashMap from values to [`Entity`]s whose
 /// components have that value.
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Resource))]
 #[derive(Resource)]
 pub struct HashmapStorage<I: IndexInfo> {
     map: UniqueMultiMap<I::Value, Entity>,
@@ -120,6 +125,8 @@ pub struct HashmapStorageRefreshData<'w, 's, I: IndexInfo> {
 /// This storage never needs to be refreshed, so [`ManualRefreshPolicy`](crate::refresh_policy::ManualRefreshPolicy)
 /// is usually the best choice for index definitions that use `NoStorage`.
 #[derive(Resource)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Resource))]
 pub struct NoStorage<I: IndexInfo> {
     phantom: PhantomData<fn() -> I>,
 }

--- a/src/unique_multimap.rs
+++ b/src/unique_multimap.rs
@@ -2,9 +2,13 @@ use bevy::utils::hashbrown::hash_set::Iter;
 use bevy::utils::{HashMap, HashSet};
 use std::hash::Hash;
 
+#[cfg(feature="reflect")]
+use bevy::{reflect::Reflect, ecs::prelude::ReflectResource};
+
 /// Map where a key can have multiple values, but a value can only exist for one key at a time.
 /// Re-inserting a value is a no-op if it already exists under the same key, otherwise the value is
 /// removed from under its present key and added under the new key.
+#[cfg_attr(feature = "reflect", derive(Reflect))]
 pub struct UniqueMultiMap<K, V> {
     map: HashMap<K, HashSet<V>>,
     rev_map: HashMap<V, K>,


### PR DESCRIPTION
## Description

This PR adds an optional `reflect` feature to allow inspecting the storage resources used by bevy_mod_index.

## Why

I would like to use bevy_inspector_egui to inspect the index as a spawn/despawn entities.